### PR TITLE
fix: tpm git repo ownership set to config user

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -53,6 +53,7 @@
     - config.plugins is defined
 
 - name: "HTH | Tmux | Checkout tmux package manager"
+  become_user: "{{ config.user }}"
   ansible.builtin.git:
     repo: 'https://github.com/tmux-plugins/tpm.git'
     dest: "{{ tmux_user_plugins_path }}/tpm"


### PR DESCRIPTION
Incorrect TPM git repository ownership now correctly set to the user who is being configured.