### PR TITLE
fix: tpm local repository change check added

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ This role installs and copies over user specific configuration files for the ter
 
 ## Requirements
 
-This role requires two separate tools be installed.
+This role requires three separate tools be installed.
 
-First it requires the `ansible.utils` collection be installed from Ansible-Galaxy via:
+First it requires `git` to be installed and on the path.
+
+Second it requires the `ansible.utils` collection be installed from Ansible-Galaxy via:
 
 ```bash
 ansible-galaxy collection install ansible.utils
 ```
 
-Secondly it requires the `jsonschema` Python package be installed.
+Third it requires the `jsonschema` Python package be installed.
 
 This can be done via `pip`:
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -52,6 +52,16 @@
   when:
     - config.plugins is defined
 
+- name: "HTH | Tmux | Detect TPM local changes"
+  ansible.builtin.command: "git -C {{ tmux_user_plugins_path }} diff --quiet || echo 'changed'"
+  register: tpm_changed
+  changed_when: false
+  failed_when: false    # Don't fail the task when rc != 0 (i.e no repo or it differs)
+  no_log: true          # Exclude git error output from being logged
+  when:
+  - config.plugins is defined
+  - config.plugins.remove is undefined or not config.plugins.remove
+
 - name: "HTH | Tmux | Checkout tmux package manager"
   become_user: "{{ config.user }}"
   ansible.builtin.git:
@@ -61,3 +71,4 @@
   when:
     - config.plugins is defined
     - config.plugins.remove is undefined or not config.plugins.remove
+    - tpm_changed.stdout != 'changed'


### PR DESCRIPTION
This adds a verification for local git repo changes before attempting to clone the remote TPM repository, as it will fail the role if there are any changes.